### PR TITLE
Add trailing freetext to callnumber

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>groupId</groupId>
     <artifactId>umich_solr_library_filters</artifactId>
-    <version>1.3.0_beta</version>
+    <version>1.3.1</version>
 
     <properties>
         <solr.version>6.6.5</solr.version>


### PR DESCRIPTION
Callnumbers were being parsed in such a way that the "extra" at the end (copy number, year, etc.) was getting thrown out. Using them now so truly exact searches will work.